### PR TITLE
将余烬手册修改为不需要解锁

### DIFF
--- a/src/config/embers.cfg
+++ b/src/config/embers.cfg
@@ -68,10 +68,10 @@ compat {
 
 misc {
     # Codex category is shut. Progression is open. [default: true]
-    B:codexCategoryIsProgress=true
+    B:codexCategoryIsProgress=false
 
     # Codex entry is shut and hide. Progression is open and show. [default: true]
-    B:codexEntryIsProgress=true
+    B:codexEntryIsProgress=false
 
     # If true, Embers homing projectiles will go for neutral players. [default: false]
     B:everybodyIsAnEnemy=false


### PR DESCRIPTION
更改了71行及74行.true改为了false. fixes#15

    # Codex category is shut. Progression is open. [default: true]
    B:codexCategoryIsProgress=false

    # Codex entry is shut and hide. Progression is open and show. [default: true]
    B:codexEntryIsProgress=false